### PR TITLE
Add output cato_lan_interface_id so it can be used to add networks to…

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,7 @@ No modules.
 |------|-------------|
 | <a name="output_boot_disk_name"></a> [boot\_disk\_name](#output\_boot\_disk\_name) | Boot disk name for the VM |
 | <a name="output_boot_disk_self_link"></a> [boot\_disk\_self\_link](#output\_boot\_disk\_self\_link) | Self-link for the boot disk |
+| <a name="output_cato_lan_interface_id"></a> [cato\_lan\_interface\_id](#output\_cato\_lan\_interface\_id) | LAN interface ID of the Cato Site Socket |
 | <a name="output_cato_license_site"></a> [cato\_license\_site](#output\_cato\_license\_site) | n/a |
 | <a name="output_cato_serial_id"></a> [cato\_serial\_id](#output\_cato\_serial\_id) | Serial ID of the Cato Site Socket |
 | <a name="output_cato_site_id"></a> [cato\_site\_id](#output\_cato\_site\_id) | ID of the Cato Socket Site |
@@ -571,8 +572,8 @@ No modules.
 | <a name="output_firewall_rule_name"></a> [firewall\_rule\_name](#output\_firewall\_rule\_name) | Name of the created firewall rule |
 | <a name="output_firewall_rule_rfc1918"></a> [firewall\_rule\_rfc1918](#output\_firewall\_rule\_rfc1918) | Firewall rule name for RFC1918 private IP ranges |
 | <a name="output_firewall_rule_rfc1918_self_link"></a> [firewall\_rule\_rfc1918\_self\_link](#output\_firewall\_rule\_rfc1918\_self\_link) | Self-link of the RFC1918 firewall rule |
+| <a name="output_vm_instance_id"></a> [vm\_instance\_id](#output\_vm\_instance\_id) | n/a |
 | <a name="output_vm_instance_name"></a> [vm\_instance\_name](#output\_vm\_instance\_name) | Name of the VM instance |
-| <a name="output_vm_instance_self_link"></a> [vm\_instance\_self\_link](#output\_vm\_instance\_self\_link) | Self-link for the VM instance |
 | <a name="output_vm_labels"></a> [vm\_labels](#output\_vm\_labels) | Labels assigned to the VM |
 | <a name="output_vm_lan_network_ip"></a> [vm\_lan\_network\_ip](#output\_vm\_lan\_network\_ip) | LAN network private IP of the VM |
 | <a name="output_vm_mgmt_network_ip"></a> [vm\_mgmt\_network\_ip](#output\_vm\_mgmt\_network\_ip) | Management network private IP of the VM |

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,11 @@ output "cato_serial_id" {
   value       = try(data.cato_accountSnapshotSite.gcp-site.info.sockets[0].serial, "N/A")
 }
 
+output "cato_lan_interface_id" {
+  description = "LAN interface ID of the Cato Site Socket"
+  value       = cato_socket_site.gcp-site.native_range.interface_id
+}
+
 output "firewall_rule_name" {
   description = "Name of the created firewall rule"
   value       = try(google_compute_firewall.allow_ssh_https[0].name, "No Firewall Rule Created")


### PR DESCRIPTION
Add output cato_lan_interface_id so it can be used to add networks to vsocket.

example:
```
resource "cato_network_range" "routed" {
  site_id       = module.vsocket-gcp.cato_site_id
  interface_id  = module.vsocket-gcp.cato_lan_interface_id
  name          = "my-network-1"
  range_type    = "Routed"
  subnet        = "172.16.10.0/24"
  gateway       = "172.16.10.1"
  internet_only = false
  depends_on = [module.vsocket-gcp]
}
```